### PR TITLE
Fix substring check for Slimefun searches

### DIFF
--- a/src/au/com/addstar/marketsearch/CommandListener.java
+++ b/src/au/com/addstar/marketsearch/CommandListener.java
@@ -472,7 +472,7 @@ class CommandListener implements CommandExecutor {
             }
         } else {
             try {
-                if ((plugin.sfEnabled) && (search.substring(0, 3).equals("sf_"))) {
+                if (plugin.sfEnabled && search.startsWith("sf_")) {
                     // Searching for Slimefun item
                     if (search.length() > 3) {
                         String sfname = search.substring(3).toUpperCase();


### PR DESCRIPTION
## Summary
- protect Slimefun item search from StringIndexOutOfBounds when the search term is short

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68425cf26e30832c91ad918821af65f0