### PR TITLE
Fix Slimefun detection and clean logging

### DIFF
--- a/src/au/com/addstar/marketsearch/CommandListener.java
+++ b/src/au/com/addstar/marketsearch/CommandListener.java
@@ -22,6 +22,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.jetbrains.annotations.NotNull;
 import com.ghostchu.quickshop.api.shop.ShopType;
+import java.util.Arrays;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -472,7 +473,7 @@ class CommandListener implements CommandExecutor {
             }
         } else {
             try {
-                if (plugin.sfEnabled && search.startsWith("sf_")) {
+                if (plugin.sfEnabled && hasSlimefunPrefix(search)) {
                     // Searching for Slimefun item
                     if (search.length() > 3) {
                         String sfname = search.substring(3).toUpperCase();
@@ -495,9 +496,8 @@ class CommandListener implements CommandExecutor {
                 }
             } catch (Exception e) {
                 sender.sendMessage(ChatColor.RED + "Invalid item name or ID");
-                plugin.debug("Exception caught: " + e.getCause());
-                plugin.debug(e.getMessage());
-                plugin.debug(e.getStackTrace().toString());
+                plugin.debug("Exception caught: " + e.getMessage());
+                plugin.debug(Arrays.toString(e.getStackTrace()));
             }
         }
         return null;
@@ -513,14 +513,9 @@ class CommandListener implements CommandExecutor {
             return null;
         }
 
-        // Check if we should override the data value with one supplied
-        if (parts.length > 1) {
-            try {
-                return def;
-            } catch (NumberFormatException e) {
-                plugin.debug("Warning: NumberFormatException caught in getItem()");
-            }
-        }
+        // In older versions this method parsed a data value from the second part
+        // of the search string. Modern Minecraft no longer uses numeric data
+        // values, so we simply return the material found above.
         return def;
     }
 
@@ -572,6 +567,10 @@ class CommandListener implements CommandExecutor {
             }
         }
         return parts;
+    }
+
+    static boolean hasSlimefunPrefix(String search) {
+        return search != null && search.toLowerCase().startsWith("sf_");
     }
 
     private void shopNotFound(Location loc) {

--- a/src/au/com/addstar/marketsearch/MarketSearch.java
+++ b/src/au/com/addstar/marketsearch/MarketSearch.java
@@ -434,24 +434,41 @@ public class MarketSearch extends JavaPlugin {
     }
 
     public boolean hasSlimefunMeta(ItemStack item) {
-        PersistentDataContainer container = item.getItemMeta().getPersistentDataContainer();
-        if (container.has(sfNSItemKey, PersistentDataType.STRING)) {
-            return true;
-        } else {
+        if (item == null || !item.hasItemMeta()) {
             return false;
         }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            return false;
+        }
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        return container.has(sfNSItemKey, PersistentDataType.STRING);
     }
 
     public sfDBItem getSlimefunItemType(ItemStack item) {
-        if (hasSlimefunMeta(item)) {
-            PersistentDataContainer container = item.getItemMeta().getPersistentDataContainer();
-            String sfname = container.get(sfNSItemKey, PersistentDataType.STRING).toUpperCase();
-            debug("Item is a Slimefun \"" + sfname + "\"");
-            return sfNameDB.getSFItem(sfname);
-        } else {
+        if (!hasSlimefunMeta(item)) {
             debug("Item is NOT Slimefun");
             return null;
         }
+
+        ItemMeta meta = item.getItemMeta();
+        if (meta == null) {
+            debug("Item meta missing while checking Slimefun type");
+            return null;
+        }
+
+        PersistentDataContainer container = meta.getPersistentDataContainer();
+        String sfname = container.get(sfNSItemKey, PersistentDataType.STRING);
+        if (sfname == null) {
+            debug("Slimefun key not present despite meta check");
+            return null;
+        }
+
+        sfname = sfname.toUpperCase();
+        debug("Item is a Slimefun \"" + sfname + "\"");
+        return sfNameDB.getSFItem(sfname);
     }
 
     public ItemStack makeSlimefunItem(ItemStack item, SlimefunNameDB.sfDBItem sfdbitem) {


### PR DESCRIPTION
## Summary
- guard against missing item meta when detecting Slimefun data
- clarify Slimefun item lookup and debug messages
- simplify unused data-value parsing logic
- log stack traces more clearly

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842634662d8832ca4aace4a7b5f69a5